### PR TITLE
Swap pry-debugger for pry-byebug and add readme badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
+language: ruby
+cache: bundler
+sudo: false
+
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.0
   - 2.1
+  - 2.2
 
 bundler_args: --jobs 7
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing to WMI-Lite
 
 We are glad you want to contribute to WMI-Lite. Please see contribution guidelines for
-[Chef](http://wiki.opscode.com/display/chef/How+to+Contribute) for information on contributing to this project.
+[Chef](https://docs.chef.io/community_contributions.html) for information on contributing to this project.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Wmi-Lite
 ========
 
+[![Build Status](https://travis-ci.org/chef/wmi-lite.svg?branch=master)](https://travis-ci.org/chef/wmi-lite)
+[![Gem Version](https://badge.fury.io/rb/wmi-lite.svg)](https://badge.fury.io/rb/wmi-lite)
+
 `wmi-lite` is a lightweight Ruby gem utility library for accessing basic
 [Windows Management Instrumentation (WMI)](http://msdn.microsoft.com/en-us/library/aa394582(v=vs.85).aspx)
 functionality on Windows. It has no dependencies outside of the Ruby interpreter
@@ -93,8 +96,8 @@ puts
 License & Authors
 -----------------
 
-Author:: Adam Edwards (<adamed@getchef.com>)
-Copyright:: Copyright (c) 2014 Chef Software, Inc.
+Author:: Adam Edwards (<adamed@chef.io>)
+Copyright:: Copyright (c) 2014-2015 Chef Software, Inc.
 License:: Apache License, Version 2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/wmi-lite.rb
+++ b/lib/wmi-lite.rb
@@ -1,5 +1,5 @@
 #
-# Author:: Adam Edwards (<adamed@getchef.com>)
+# Author:: Adam Edwards (<adamed@chef.io>)
 # Copyright:: Copyright 2014 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #

--- a/lib/wmi-lite/wmi.rb
+++ b/lib/wmi-lite/wmi.rb
@@ -1,5 +1,5 @@
 #
-# Author:: Adam Edwards (<adamed@getchef.com>)
+# Author:: Adam Edwards (<adamed@chef.io>)
 # Copyright:: Copyright 2014 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #

--- a/lib/wmi-lite/wmi_exception.rb
+++ b/lib/wmi-lite/wmi_exception.rb
@@ -1,5 +1,5 @@
 #
-# Author:: Adam Edwards (<adamed@getchef.com>)
+# Author:: Adam Edwards (<adamed@chef.io>)
 # Copyright:: Copyright 2014 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
@@ -74,4 +74,4 @@ module WmiLite
     end
   end
 end
-    
+

--- a/lib/wmi-lite/wmi_instance.rb
+++ b/lib/wmi-lite/wmi_instance.rb
@@ -1,5 +1,5 @@
 #
-# Author:: Adam Edwards (<adamed@getchef.com>)
+# Author:: Adam Edwards (<adamed@chef.io>)
 # Copyright:: Copyright 2014 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #

--- a/spec/functional/wmi_spec.rb
+++ b/spec/functional/wmi_spec.rb
@@ -1,5 +1,5 @@
 #
-# Author:: Adam Edwards (<adamed@getchef.com>)
+# Author:: Adam Edwards (<adamed@chef.io>)
 #
 # Copyright:: 2014, Chef Software, Inc.
 #
@@ -76,18 +76,18 @@ describe WmiLite::Wmi, :windows_only do
     let(:cardinality_transform) { lambda{|x| x} }
     context 'using first_of' do
       let(:cardinality_transform) { lambda{|x| x.nil? ? [] : [x] } }
-      let(:query_method) { :first_of } 
+      let(:query_method) { :first_of }
       it_behaves_like 'a valid WMI query'
     end
 
     context 'using instances_of' do
-      let(:query_method) { :instances_of } 
+      let(:query_method) { :instances_of }
       it_behaves_like 'a valid WMI query'
     end
 
     context 'using query' do
       let(:wmi_query) { "select * from #{wmi_class}" }
-      let(:query_method) { :query } 
+      let(:query_method) { :query }
       it_behaves_like 'a valid WMI query'
     end
   end
@@ -132,13 +132,13 @@ describe WmiLite::Wmi, :windows_only do
 
           # Turn %SYSTEMROOT% into c:\windows
           # so we can compare with what's in ENV
-          evaluated_value = `echo #{value}`.strip 
+          evaluated_value = `echo #{value}`.strip
 
           expect(evaluated_value).to eql(`echo #{ENV[name]}`.strip)
           verified_count += 1
         end
       end
-      
+
       # There are at least 3 variables we could verify in a default
       # Windows configuration, make sure we saw some
       expect(verified_count).to be >= 3
@@ -151,7 +151,7 @@ describe WmiLite::Wmi, :windows_only do
     caption_mixed = result['Caption']
     caption_lower = result['caption']
 
-    expect(caption_mixed.nil?).to eql(false) 
+    expect(caption_mixed.nil?).to eql(false)
     expect(caption_lower.nil?).to eql(false)
 
     expect(caption_mixed.length).to be > 0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require 'wmi-lite'
 
 RSpec.configure do |config|
   config.include(RSpec::Matchers)
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.filter_run :focus => true
   config.filter_run_excluding :windows_only => true if ! (RUBY_PLATFORM =~ /mswin|mingw32|windows/)
   config.run_all_when_everything_filtered = true

--- a/spec/unit/wmi_spec.rb
+++ b/spec/unit/wmi_spec.rb
@@ -1,5 +1,5 @@
 #
-# Author:: Adam Edwards (<adamed@getchef.com>)
+# Author:: Adam Edwards (<adamed@chef.io>)
 #
 # Copyright:: 2014, Chef Software, Inc.
 #

--- a/wmi-lite.gemspec
+++ b/wmi-lite.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'pry-debugger'
+  spec.add_development_dependency 'pry-byebug'
 end

--- a/wmi-lite.gemspec
+++ b/wmi-lite.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'wmi-lite'
   spec.version       = WmiLite::VERSION
   spec.authors       = ['Adam Edwards']
-  spec.email         = ['dev@getchef.com']
+  spec.email         = ['dev@chef.io']
   spec.description   = 'A lightweight utility over win32ole for accessing basic ' \
                        'WMI (Windows Management Instrumentation) functionality ' \
                        'in the Microsoft Windows operating system. It has no '  \


### PR DESCRIPTION
Pry-debugger hasn't been updated for Ruby 2+ and their Github site recommends using pry-byebug for Ruby 2+.  This also adds rubygem and travis badges.  While I was in here I updated getchef.com -> chef.io and fixed the contributing URL.