### PR TITLE
Inherit from StandardError instead of Exception for default rescue case

### DIFF
--- a/lib/wmi-lite/wmi_exception.rb
+++ b/lib/wmi-lite/wmi_exception.rb
@@ -17,7 +17,7 @@
 #
 
 module WmiLite
-  class WmiException < Exception
+  class WmiException < StandardError
     def initialize(exception, wmi_method_context, namespace, query = nil, class_name = nil)
       error_message = exception.message
       error_code = translate_error_code(error_message)


### PR DESCRIPTION
https://ruby-doc.org/core-2.3.3/StandardError.html

StandardError

The most standard error types are subclasses of StandardError. A rescue clause
without an explicit Exception class will rescue all StandardErrors (and only
those).