### PR TITLE
Slim the files we ship in the gem

### DIFF
--- a/wmi-lite.gemspec
+++ b/wmi-lite.gemspec
@@ -18,9 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/chef/wmi-lite'
   spec.license       = 'Apache-2.0'
 
-  spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = %w{LICENSE} + Dir.glob("lib/**/*")
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
Only ship the license the the lib dir in the artifact.

Signed-off-by: Tim Smith <tsmith@chef.io>