### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/wmi-lite.rb
+++ b/lib/wmi-lite.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Edwards (<adamed@chef.io>)
-# Copyright:: Copyright 2014 Chef Software, Inc.
+# Copyright:: Copyright 2014-2019 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,4 +16,4 @@
 # limitations under the License.
 #
 
-require "wmi-lite/wmi"
+require_relative 'wmi-lite/wmi'

--- a/lib/wmi-lite/wmi.rb
+++ b/lib/wmi-lite/wmi.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Edwards (<adamed@chef.io>)
-# Copyright:: Copyright 2014 Chef Software, Inc.
+# Copyright:: Copyright 2014-2019 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,9 +16,9 @@
 # limitations under the License.
 #
 
-require "win32ole" if RUBY_PLATFORM =~ /mswin|mingw32|windows/
-require "wmi-lite/wmi_instance"
-require "wmi-lite/wmi_exception"
+require 'win32ole' if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+require_relative 'wmi_instance'
+require_relative 'wmi_exception'
 
 module WmiLite
   class Wmi

--- a/lib/wmi-lite/wmi_exception.rb
+++ b/lib/wmi-lite/wmi_exception.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Edwards (<adamed@chef.io>)
-# Copyright:: Copyright 2014 Chef Software, Inc.
+# Copyright:: Copyright 2014-2019 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/wmi-lite/wmi_instance.rb
+++ b/lib/wmi-lite/wmi_instance.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Adam Edwards (<adamed@chef.io>)
-# Copyright:: Copyright 2014 Chef Software, Inc.
+# Copyright:: Copyright 2014-2019 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>