### PR TITLE
Replace deprecated --without flag with bundle config

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -39,7 +39,8 @@ steps:
         image: ruby:2.7-buster
 - label: run-specs-windows
   command:
-    - bundle install --jobs=7 --retry=3 --without docs debug
+    - bundle config set --local without docs debug
+    - bundle install --jobs=7 --retry=3
     - bundle exec rake spec
   expeditor:
     executor:

--- a/Gemfile
+++ b/Gemfile
@@ -19,5 +19,5 @@ group :debug do
   gem "pry"
   gem "pry-byebug"
   gem "rb-readline"
-  gem "simplecov", "~> 0.9"
+  gem "simplecov", "~> 0.18.5" # pin until we drop ruby support 2.4
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ end
 group :test do
   gem "chefstyle", "= 1.2.0"
   gem "rspec", "~> 3.1"
+  gem "docile", "~> 1.3.5" # pin until we drop ruby support 2.4
   gem "rake"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ end
 group :debug do
   gem "pry"
   gem "pry-byebug"
-  gem "pry-stack_explorer", "~> 0.4.0" # pin until we drop ruby < 2.6
   gem "rb-readline"
   gem "simplecov", "~> 0.9"
 end


### PR DESCRIPTION
Replacing **--without** flag with **bundle config** to get rid of bundler deprecated warning :

[DEPRECATED] The --without flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use bundle config set without 'development doc', and stop using this flag



Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG